### PR TITLE
Add GitHub Action workflow to build and upload Rust binary

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,31 @@
+name: Build and Upload Rust Binary
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install nix
+        uses: cachix/install-nix-action@v27
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+
+      - name: Build binary
+        run: nix-shell shell.nix --run 'cargo build --release'
+
+      - name: Upload built binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: aria-cli.exe
+          path: target/x86_64-pc-windows-gnu/release/aria-cli.exe

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # Aria
 
 A simple screen reader for windows.
+
+## GitHub Action Workflow
+
+This repository includes a GitHub Action workflow for building and uploading the Rust binary. The workflow is triggered on push and pull request events to the `main` branch. It sets up the Rust toolchain, builds the Rust binary, and uploads it as a built artifact.


### PR DESCRIPTION
Related to #2

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Coyenn/Aria/pull/3?shareId=6001eb71-71ec-4c8c-bdee-33fa4f242234).